### PR TITLE
Add force refresh database property

### DIFF
--- a/src/Testing/FeatureTestCase.php
+++ b/src/Testing/FeatureTestCase.php
@@ -4,6 +4,7 @@ namespace Aic\Hub\Foundation\Testing;
 
 use Tests\CreatesApplication;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\RefreshDatabaseState;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class FeatureTestCase extends BaseTestCase
@@ -22,6 +23,10 @@ abstract class FeatureTestCase extends BaseTestCase
 
     protected function setUp(): void
     {
+        if (property_exists($this, 'forceRefresh') && $this->forceRefresh) {
+            RefreshDatabaseState::$migrated = false;
+        }
+
         parent::setUp();
 
         foreach (class_uses_recursive($this) as $trait) {


### PR DESCRIPTION
Laravel tries to be smart about when it refreshes the database, but sometimes you *absolutely* need it to refresh, whether Laravel agrees or not. Set the property `protected $forceRefresh = true;` on the test case to force refreshes.