### PR TITLE
Set PHP CodeSniffer report to full

### DIFF
--- a/phpcs.dist.xml
+++ b/phpcs.dist.xml
@@ -33,5 +33,5 @@
 
     <!-- Show progress and display sniff details in output -->
     <arg value="ps"/>
-    <arg name="report" value="summary" />
+    <arg name="report" value="full" />
 </ruleset>


### PR DESCRIPTION
This has been bugging me the past couple of weeks, so I updated the report CodeSniffer prints from summary:
```
PHP CODE SNIFFER REPORT SUMMARY
---------------------------------------------------------------------------------------
FILE                                                                   ERRORS  WARNINGS
---------------------------------------------------------------------------------------
...ms/database/migrations/2023_09_19_150611_rename_artworks_table.php  1       0
---------------------------------------------------------------------------------------
A TOTAL OF 1 ERROR AND 0 WARNINGS WERE FOUND IN 1 FILE
---------------------------------------------------------------------------------------
PHPCBF CAN FIX 1 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
---------------------------------------------------------------------------------------
```

... to full, which includes a line number and explanation of the errors:
```
---------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
---------------------------------------------------------------------------------------
 6 | ERROR | [x] Expected 1 space after class keyword; 0 found
   |       |     (PSR12.Classes.AnonClassDeclaration.SpaceAfterKeyword)
---------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
---------------------------------------------------------------------------------------
```