### PR TITLE
Provide a sensible default for the `columns` passed to an Elasticsearch query [WEB-3038]

### DIFF
--- a/src/Library/Api/Builders/ApiModelBuilderSearch.php
+++ b/src/Library/Api/Builders/ApiModelBuilderSearch.php
@@ -32,6 +32,10 @@ class ApiModelBuilderSearch extends ApiModelBuilder
                 $columns
             );
         }
+        else {
+            $columns = ['*'];
+        }
+
         $results = $this->forPage($page, $perPage)->get($columns);
 
         $paginationData = $results->getMetadata('pagination');


### PR DESCRIPTION
When a value for the `columns` parameter is not specified, Elasticsearch is used to return all fields. In ES 8.x, a blank `fields` parameter will return no fields. This was breaking autosuggestions in the website's global search.